### PR TITLE
improve getting video mode info (bsc#1181101)

### DIFF
--- a/mdt.c
+++ b/mdt.c
@@ -19,14 +19,17 @@
 
 #define STR_SIZE 128
 
+#define VBIOS_MEM	0xa0000
+#define VBIOS_MEM_SIZE	0x10000
+
 #define VBIOS_ROM	0xc0000
 #define VBIOS_ROM_SIZE	0x10000
 
+#define VBIOS_GAP1	0xd0000
+#define VBIOS_GAP1_SIZE	0x20000
+
 #define SBIOS_ROM	0xf0000
 #define SBIOS_ROM_SIZE	0x10000
-
-#define VBIOS_MEM	0xa0000
-#define VBIOS_MEM_SIZE	0x10000
 
 #define VBE_BUF		0x8000
 
@@ -413,7 +416,7 @@ unsigned vm_run(x86emu_t *emu, double *t)
 {
   unsigned err;
 
-  if(opt.verbose >= 2) x86emu_log(emu, "=== emulation log ===\n");
+  if(opt.verbose >= 2) x86emu_log(emu, "=== emulation log %s===\n", opt.no_io ? "(no i/o) " : "");
 
   *t = get_time();
 
@@ -659,6 +662,9 @@ int vm_prepare(vm_t *vm)
 
   // stack & buffer space
   x86emu_set_perm(vm->emu, VBE_BUF, 0xffff, X86EMU_PERM_RW);
+
+  // make memory between mapped VBIOS ROM areas writable
+  x86emu_set_perm(vm->emu, VBIOS_GAP1, VBIOS_GAP1 + VBIOS_GAP1_SIZE - 1, X86EMU_PERM_RW);
 
   vm->emu->log.trace = opt.trace_flags;
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1181101
- https://trello.com/c/X3jmQke2

When blocking all I/O accesses infinite loops might show up waiting indefinitely for something to happen.

In the reported case it is reading the ACPI timer waiting for some time to elapse.

## Solution

Try to emulate some activity on the emulated port if a close reading loop is detected.

## Related

The same patch in `hwinfo`: https://github.com/openSUSE/hwinfo/pull/92